### PR TITLE
Add support for {:set_case:pascal}

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Supported values:
 - upper -- "FIRST SECOND THIRD"
 - title -- "First Second Third"
 - camel -- "first Second Third". Generally used with `{:set_space:}` to give "firstSecondThird"
+- pascal -- "First Second Third". Generally used with `{:set_space:}` to give "FirstSecondThird"
 
 Example usage:
 

--- a/state.cc
+++ b/state.cc
@@ -11,6 +11,7 @@ constexpr StenoCaseMode StenoState::NEXT_WORD_CASE_MODE[] = {
     StenoCaseMode::UPPER,  // UPPER
     StenoCaseMode::TITLE,  // TITLE
     StenoCaseMode::TITLE,  // CAMEL
+    StenoCaseMode::TITLE,  // PASCAL
     StenoCaseMode::NORMAL, // LOWER_ONCE
     StenoCaseMode::NORMAL, // UPPER_ONCE
     StenoCaseMode::NORMAL, // TITLE_ONCE
@@ -22,6 +23,7 @@ constexpr StenoCaseMode StenoState::NEXT_LETTER_CASE_MODE[] = {
     StenoCaseMode::UPPER,      // UPPER
     StenoCaseMode::NORMAL,     // TITLE
     StenoCaseMode::NORMAL,     // CAMEL
+    StenoCaseMode::UPPER,      // PASCAL
     StenoCaseMode::LOWER_ONCE, // LOWER_ONCE
     StenoCaseMode::UPPER_ONCE, // UPPER_ONCE
     StenoCaseMode::NORMAL,     // TITLE_ONCE

--- a/state.h
+++ b/state.h
@@ -12,6 +12,7 @@ enum class StenoCaseMode : uint8_t {
   UPPER,
   TITLE,
   CAMEL,
+  PASCAL,
   LOWER_ONCE,
   UPPER_ONCE,
   TITLE_ONCE,

--- a/steno_key_code.cc
+++ b/steno_key_code.cc
@@ -10,6 +10,8 @@ uint32_t StenoKeyCode::ResolveUnicodeInterrnal(uint32_t unicode,
   case StenoCaseMode::NORMAL:
   case StenoCaseMode::CAMEL:
     return unicode;
+  case StenoCaseMode::PASCAL:
+    return unicode;
   case StenoCaseMode::LOWER:
   case StenoCaseMode::LOWER_ONCE:
     return Unicode::ToLower(unicode);

--- a/steno_key_code_buffer_functions.cc
+++ b/steno_key_code_buffer_functions.cc
@@ -780,6 +780,11 @@ bool StenoKeyCodeBuffer::SetCaseFunction(const List<char *> &parameters) {
     return true;
   }
 
+  if (Str::Eq(parameters[1], "pascal")) {
+    state.overrideCaseMode = StenoCaseMode::PASCAL;
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
I know your repo said that you're not accepting PRs. But some recent change in javelin broke something I use quite a lot: my Pascal case assignment: "{mode:camel}{-|}". I'm a Microsoft stack software architect, working in a Microsoft stack environment. It's often that I need Pascal casing because of the naming conventions in the C# community. I'll email you about this PR as well - if there's an alternative I can use to get Pascal casing, I'm happy to adjust my dictionary to suit.